### PR TITLE
chore: add CSS variables and semantic tokens for color palette

### DIFF
--- a/src/Styles/App.css
+++ b/src/Styles/App.css
@@ -1,6 +1,54 @@
 @import url("https://fonts.googleapis.com/css2?family=Josefin+Sans:wght@100;200;300;400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=Maven+Pro:wght@400;500;600;700;800;900&display=swap");
 
+:root {
+  /* Brand colors: CTA's active and focused states */
+  --color-primary-100: #EDF1F4;
+  --color-primary-200: #CDD7E2;
+  --color-primary-300: #3B5998;
+  --color-primary-400: #455C80;
+  --color-primary-500: #1D3967;
+
+  /* Neutral greys: text, backgrounds, surfaces, dividers */
+  --color-neutral-100: #FFFFFF;
+  --color-neutral-200: #F2F1EC;
+  --color-neutral-300: #D9D9D9;
+  --color-neutral-400: #999999;
+  --color-neutral-500: #212529;
+
+  /* Feedback */
+  --color-success-100: #E9F4E8;
+  --color-success-500: #458532;
+
+  --color-info-100: #ECF0FC;
+  --color-info-500: #3A5FDD;
+
+  --color-warning-100: #FCF9E8;
+  --color-warning-500: #EBC341;
+
+  --color-error-100: #F8E8E9;
+  --color-error-500: #C82026;
+
+  /*** Tokens ***/
+
+  /* Text */
+  --text-heading:   var(--color-primary-500); /* Headings, titles, highlights */
+  --text-body:      var(--color-neutral-500); /* Main body text */
+  --text-inverse:   var(--color-neutral-100); /* Text on dark background */
+  --text-link:      var(--color-primary-300); /* Links */
+  --text-help:      var(--color-neutral-400); /* Help text labels */
+
+  /* Background */
+  --bg-default:     var(--color-neutral-100); /* Page background */
+  --bg-surface:     var(--color-neutral-200); /* Cards/panel background */
+  --bg-primary:     var(--color-primary-500); /* Primary background */
+  --bg-disabled:    var(--color-neutral-200); /* Disabled background */
+
+  /* Borders & Dividers */
+  --border-default: var(--color-neutral-300); /* Inputs, separators, cards */
+  --border-strong:  var(--color-neutral-400); /* Emphasized borders and separators */
+}
+
 @font-face {
   font-family: Oblik;
   font-weight: bold;

--- a/src/components/Recommendations/Recommendations.module.scss
+++ b/src/components/Recommendations/Recommendations.module.scss
@@ -83,14 +83,17 @@
   figcaption {
     display: flex;
     flex-direction: column;
-    gap: 0.8rem;
+    gap: 0.2rem;
 
     h3 {
       font-family: Josefin Sans;
       font-size: 1.25rem;
       font-weight: 500;
+      color: var(--text-heading);
+      padding-bottom: 0.5rem;
+      border-bottom: 1px solid var(--color-primary-100);
 
-      @media (min-width: 1280px) {
+      @media (min-width: 80em) {
         font-size: 1.5rem;
       }
     }
@@ -98,7 +101,12 @@
     p {
       font-size: 1rem;
       font-weight: 300;
+      color: var(--text-body);
       margin-bottom: 0rem; // Workaround: overwrites bootstrap styling
+
+      @media (min-width: 80em) {
+        font-size: 1.2rem;
+      }
     }
   }
 }


### PR DESCRIPTION
- Added global CSS variables (`:root`) for the color **palette** (primary, neutral, feedback).
- Created **semantic tokens** for text, background and borders to avoid hardcoding hex values.
- Align implementation with the **Figma design system palette** provided by the UX team.

## How to use
- In SCSS modules or CSS:
  ```scss
  .button {
    background: var(--bg-primary);
    color: var(--text-inverse);
  }

  .heading {
    color: var(--text-heading);
  }