### PR TITLE
Feat: add reusable buttons

### DIFF
--- a/src/components/Shared/Button/Button.jsx
+++ b/src/components/Shared/Button/Button.jsx
@@ -4,6 +4,10 @@ import { WithTransLate } from "../../helpers/translating/index";
 
 import s from "./Button.module.scss";
 
+/**
+ * @deprecated This Button component is deprecated.
+ * Please use the Button component from Shared/ui/Button instead.
+ */
 const Button = ({
   text = "",
   icon = null,

--- a/src/components/Shared/ui/Button.jsx
+++ b/src/components/Shared/ui/Button.jsx
@@ -1,0 +1,42 @@
+import PropTypes from "prop-types";
+import s from "./LinkButton.module.scss";
+
+function Button({
+  variant = "primary",
+  disabled = false,
+  className = "",
+  onClick,
+  children,
+  ...props
+}) {
+  const classes = [
+    s.btn,
+    s[`btn--${variant}`],
+    disabled ? s["is-disabled"] : "",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <button
+      type="button"
+      className={classes}
+      disabled={disabled}
+      onClick={onClick}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}
+
+Button.propTypes = {
+  variant: PropTypes.oneOf(["primary", "secondary"]),
+  disabled: PropTypes.bool,
+  className: PropTypes.string,
+  onClick: PropTypes.func,
+  children: PropTypes.node.isRequired,
+};
+
+export default Button;

--- a/src/components/Shared/ui/IconButton.jsx
+++ b/src/components/Shared/ui/IconButton.jsx
@@ -1,0 +1,77 @@
+import PropTypes from "prop-types";
+import {
+  HiOutlineChevronLeft,
+  HiOutlineChevronRight,
+  HiOutlineChevronUp,
+  HiOutlineChevronDown,
+  HiOutlineArrowUp,
+  HiOutlineArrowDown,
+} from "react-icons/hi";
+
+import s from "./IconButton.module.scss";
+
+const icons = {
+  //Chevrons
+  chevronLeft: HiOutlineChevronLeft,
+  chevronRight: HiOutlineChevronRight,
+  chevronUp: HiOutlineChevronUp,
+  chevronDown: HiOutlineChevronDown,
+
+  //Arrows
+  arrowUp: HiOutlineArrowUp,
+  arrowDown: HiOutlineArrowDown,
+};
+
+function IconButton({
+  id,
+  icon,
+  variant = "neutral",
+  size = "md",
+  iconSize = 24,
+  disabled = false,
+  onClick,
+  className = "",
+  ...props
+}) {
+  const Icon = icons[icon];
+  const classes = [
+    s.iconButton,
+    s[`iconButton--${variant}`],
+    s[`iconButton--${size}`],
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <button
+      id={id}
+      type="button"
+      className={classes}
+      disabled={disabled}
+      {...(onClick ? { onClick } : {})}
+      {...props}
+    >
+      <Icon size={iconSize} aria-hidden="true" />
+    </button>
+  );
+}
+
+IconButton.propTypes = {
+  icon: PropTypes.oneOf([
+    "chevronLeft",
+    "chevronRight",
+    "chevronUp",
+    "chevronDown",
+    "arrowUp",
+    "arrowDown",
+  ]).isRequired,
+  variant: PropTypes.oneOf(["neutral", "primary", "inverse"]),
+  size: PropTypes.oneOf(["sm", "md", "lg"]),
+  iconSize: PropTypes.number,
+  className: PropTypes.string,
+  disabled: PropTypes.bool,
+  onClick: PropTypes.func,
+};
+
+export default IconButton;

--- a/src/components/Shared/ui/IconButton.module.scss
+++ b/src/components/Shared/ui/IconButton.module.scss
@@ -1,0 +1,74 @@
+.iconButton {
+  /* Default */
+  --ib-size: 35px;
+  --ib-fg: var(--color-neutral-500);
+  --ib-bg: var(--color-neutral-100);
+  --ib-border: var(--color-neutral-500);
+  --ib-bg-hover: var(--color-neutral-300);
+  --ib-fg-hover: var(--color-neutral-500);
+
+  background-color: var(--ib-bg);
+  border: 1px solid var(--ib-border);
+  border-radius: 50%;
+  color: var(--ib-fg);
+
+  width: var(--ib-size);
+  height: var(--ib-size);
+
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+
+  pointer-events: auto;
+  transition: background-color .15s ease, color .15s ease, border-color .15s ease;
+
+  /* Sizes */
+  &--sm {
+    --ib-size: 28px;
+  }
+
+  &--md {
+    --ib-size: 35px;
+  }
+
+  // default
+  &--lg {
+    --ib-size: 44px;
+  }
+
+  /* Variants */
+  &--neutral {
+    --ib-fg: var(--color-neutral-500);
+    --ib-bg: var(--color-neutral-100);
+    --ib-border: var(--color-neutral-500);
+    --ib-bg-hover: var(--color-neutral-300);
+    --ib-fg-hover: var(--color-neutral-500);
+  }
+
+  &--inverse {
+    --ib-fg: var(--color-neutral-100);
+    --ib-bg: var(--color-primary-500);
+    --ib-border: var(--color-primary-500);
+    --ib-bg-hover: var(--color-neutral-100);
+    --ib-fg-hover: var(--color-primary-500)
+  }
+
+  &:hover,
+  &:active {
+    background-color: var(--ib-bg-hover);
+    color: var(--ib-fg-hover);
+  }
+
+
+  &:focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: 3px;
+  }
+
+
+  &:disabled {
+    opacity: .5;
+    cursor: not-allowed;
+    pointer-events: none;
+  }
+}

--- a/src/components/Shared/ui/Link.jsx
+++ b/src/components/Shared/ui/Link.jsx
@@ -1,0 +1,61 @@
+import PropTypes from "prop-types";
+import s from "./LinkButton.module.scss";
+
+function Link({
+  variant = "primary",
+  href,
+  target,
+  rel,
+  className = "",
+  disabled = false,
+  children,
+  ...props
+}) {
+  const classes = [
+    s.btn,
+    s[`btn--${variant}`],
+    disabled ? s["is-disabled"] : "",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const finalRel =
+    target === "_blank"
+      ? [rel, "noopener", "noreferrer"].filter(Boolean).join(" ")
+      : rel;
+
+  const handleClick = (e) => {
+    if (disabled) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+  };
+
+  return (
+    <a
+      className={classes}
+      href={disabled ? undefined : href}
+      target={target}
+      rel={finalRel}
+      aria-disabled={disabled || undefined}
+      tabIndex={disabled ? -1 : undefined}
+      onClick={handleClick}
+      {...props}
+    >
+      {children}
+    </a>
+  );
+}
+
+Link.propTypes = {
+  variant: PropTypes.oneOf(["primary", "secondary"]),
+  href: PropTypes.string,
+  target: PropTypes.string,
+  rel: PropTypes.string,
+  className: PropTypes.string,
+  disabled: PropTypes.bool,
+  children: PropTypes.node.isRequired,
+};
+
+export default Link;

--- a/src/components/Shared/ui/LinkButton.module.scss
+++ b/src/components/Shared/ui/LinkButton.module.scss
@@ -1,0 +1,86 @@
+.btn {
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  padding: .6rem .8rem;
+  border: 2px solid transparent;
+  text-decoration: none;
+  cursor: pointer;
+
+  transition: background-color .15s ease, color .15s ease, border-color .15s ease;
+
+  /* Typography */
+  font-size: .9rem;
+  font-weight: 400;
+  text-transform: uppercase;
+
+  &:focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: 3px;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: .6;
+    pointer-events: none;
+    box-shadow: none;
+  }
+}
+
+.is-disabled {
+  cursor: not-allowed;
+  opacity: .6;
+  box-shadow: none;
+}
+
+/* variants */
+.btn--primary {
+  --bg: var(--color-primary-500);
+  --fg: var(--color-neutral-100);
+  --bg-hover: var(--color-neutral-100);
+  --fg-hover: var(--color-primary-500);
+  --bg-disabled: var(--color-neutral-200);
+  --fg-disabled: var(--color-neutral-400);
+
+  background-color: var(--bg);
+  color: var(--fg);
+  border-color: var(--bg);
+
+  &:hover {
+    background-color: var(--bg-hover);
+    color: var(--fg-hover);
+  }
+
+  &:disabled {
+    background-color: var(--bg-disabled);
+    color: var(--fg-disabled);
+    border-color: var(--bg-disabled);
+  }
+}
+
+.btn--secondary {
+  --bg: var(--color-neutral-100);
+  --fg: var(--color-primary-500);
+  --bg-hover: var(--color-primary-500);
+  --fg-hover: var(--color-neutral-100);
+  --bg-disabled: var(--color-neutral-200);
+  --fg-disabled: var(--color-neutral-400);
+
+  background-color: var(--bg);
+  color: var(--fg);
+  border-color: var(--color-primary-500);
+
+  &:hover {
+    background-color: var(--bg-hover);
+    color: var(--fg-hover);
+    border-color: var(--bg-hover);
+  }
+
+  &:disabled {
+    background-color: var(--bg-disabled);
+    color: var(--fg-disabled);
+    border-color: var(--bg-disabled);
+  }
+}


### PR DESCRIPTION
- Added reusable Button, Link and IconButton components.
- Button and Link share the same SCSS module with `primary | secondary` variants.
- Button props: `variant, disabled, className, onClick, children, ...props`.
- Link props: `variant, href, target, rel, className, disabled, childre, ...props`.
- IconButton is styled to match Figma (chevrons in all directions + arrow (only up and down).
   It accepts the following props: `id, icon, variant, size, iconSize, disabled, onClick, className, ...props.`
   
- The previous `Button` component in `Shared/Button` has been marked as deprecated.
The new reusable `Button`, `Link`, and `IconButton` components are available under `Shared/ui`.

## How to use

```jsx
// Button
<Button>Primary</Button>
<Button variant="secondary">Secondary</Button>
<Button disabled>Disabled</Button>

// Link
<Link href="/about">Internal</Link>
<Link href="https://example.com" target="_blank" variant="primary">External</Link>
<Link href="/terms" disabled>Disabled</Link>

// IconButton
<IconButton icon="chevronRight" variant="primary" size="lg" />
<IconButton icon="arrowUp" variant="inverse" size="sm" />