### PR TITLE
fix: remove global config for focus and active in Header

### DIFF
--- a/src/Styles/App.css
+++ b/src/Styles/App.css
@@ -47,7 +47,14 @@
   /* Borders & Dividers */
   --border-default: var(--color-neutral-300); /* Inputs, separators, cards */
   --border-strong:  var(--color-neutral-400); /* Emphasized borders and separators */
+
+
+  /* Focus */ 
+  --focus-ring-color: var(--color-primary-500);
+  --focus-ring-width: 2px;
+  --focus-ring-offset: 3px;
 }
+
 
 @font-face {
   font-family: Oblik;
@@ -134,6 +141,24 @@ a {
 .MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline {
   border-color: rgba(0, 0, 0, 0.23) !important;
   border-width: 1px !important;
+}
+
+/* Focus rings and accessibility */
+*:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+/* Show focus ring for keyboard users (accessibility) */
+:is(button,
+  a[href],
+  input:not([type="hidden"]),
+  select,
+  textarea,
+  [role="button"],
+  [tabindex]:not([tabindex="-1"])):focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
 }
 
 .App {

--- a/src/components/header/Header.module.scss
+++ b/src/components/header/Header.module.scss
@@ -191,9 +191,3 @@
     }
   }
 }
-
-*:focus, *:active {
-  outline: none !important;
-  border: none !important;
-  box-shadow: none !important;
-}


### PR DESCRIPTION
# What's changed
- Removed global reset of `*:focus, *active` with `!important` from `Header.module.scss` (it was overriding all focus styles unintentionally).
- Added proper focus handling in `app.css`:
   - `:focus:not(:focus-visible)` hides focus outline for mouse/touch.
   - `:focus:visible` shows an accessible focus ring for keyboard navigation.
 
 ## Why
 - Prevents all focus styles from being suppressed by a local component override.
 - Ensure acessibility for keyboard users.
 - Keep UI clean for mouse/touch users.
 
 ## How to test
 - Tab through buttons/links → focus ring visible and consistent.
- Click with mouse → no focus ring shown.
- Form controls (inputs, selects, textareas) → same accessible behavior.