### PR TITLE
fix: prevent box-shadow flicker on accommodation's modal

### DIFF
--- a/src/components/PhotoGallery/DesctopGallerySection/MyModal.css
+++ b/src/components/PhotoGallery/DesctopGallerySection/MyModal.css
@@ -21,11 +21,22 @@
   max-width: calc(100vw - 64px);
   background: #fff;
   border: 1px solid rgba(0, 0, 0, 0.08);
-  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.18);
+  box-shadow: none;
   padding: 32px 104px;
   outline: none;
   -webkit-tap-highlight-color: transparent;
   cursor: default;
+  transform: translateZ(0);
+  backface-visibility: hidden;
+}
+
+.bh-modal::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.18);
 }
 
 /* Disable background interactions while modal is open */
@@ -40,14 +51,11 @@
   pointer-events: auto !important;
 }
 
-/* Guard against unwanted global active/transform effects */
-.bh-modal-open,
-.bh-modal-open *:active,
-.bh-modal-open .bh-backdrop:active,
-.bh-modal-open .bh-modal:active {
+/* Guard against unwanted transform/filter interactions */
+.bh-modal-open .bh-modal *:active,
+.bh-modal-open .bh-backdrop *:active {
   transform: none !important;
   filter: none !important;
-  box-shadow: none !important;
 }
 .bh-modal-open .bh-modal,
 .bh-modal-open .bh-modal * {

--- a/src/components/PhotoGallery/DesctopGallerySection/Mymodal.jsx
+++ b/src/components/PhotoGallery/DesctopGallerySection/Mymodal.jsx
@@ -193,12 +193,10 @@ html.bh-modal-open .bh-modal {
   transform: none !important;
   filter: none !important;
 }
-html.bh-modal-open *:active,
-html.bh-modal-open .bh-modal:active,
-html.bh-modal-open .bh-backdrop:active {
+html.bh-modal-open .bh-modal *:active,
+html.bh-modal-open .bh-backdrop *:active {
   transform: none !important;
   filter: none !important;
-  box-shadow: none !important;
 }
 html.bh-modal-open .bh-modal,
 html.bh-modal-open .bh-modal * {


### PR DESCRIPTION
- Cleaned guard CSS in order to avoid removing modal shadows during active states.
- Moved modal box-shadow to `::before` pseudo-element so it’s not affected by `:active/focus` styles.
- Added onMouseDown `preventDefault` to both `IconButton` to avoid unwanted active/focus repaint.
