### PR TITLE
fix: adjust recommendation and review sections to container

### DIFF
--- a/src/components/Recommendations/Recommendations.module.scss
+++ b/src/components/Recommendations/Recommendations.module.scss
@@ -14,10 +14,9 @@
   }
   @media (min-width: 960px) {
     margin-top: 30px;
-    width: 660px;
+    width: 100%;
   }
   @media (min-width: 1280px) {
-    width: 94%;
     padding-left: 0;
     padding-top: 50px;
     padding-right: 0px;
@@ -30,7 +29,7 @@
   gap: 1rem;
 
   @media (min-width: 1280px) {
-    gap:50px;
+    gap: 6rem;
     flex-direction: row;
   }
 }

--- a/src/components/ReviewSlider/ReviewSection.module.scss
+++ b/src/components/ReviewSlider/ReviewSection.module.scss
@@ -4,11 +4,13 @@ $smallScreen: 60em; // ~960px
 $tablet: 48em; // ~768px
 
 .section {
-  padding: 1rem;
+  padding: 1rem 2rem;
+  margin-bottom: 3rem;
 
   display: flex;
   flex-direction: column;
   align-items: flex-start;
+  gap: 1.2rem;
 
   overflow: hidden;
 
@@ -17,10 +19,12 @@ $tablet: 48em; // ~768px
   }
 
   @media (min-width: $desktop) {
+    padding: 0;
     height: 22.75rem;
+    width: 100%;
 
     flex-direction: row;
-    gap: 1rem;
+    gap: 4rem;
   }
 
   h3 {


### PR DESCRIPTION
- Adjust `Recommendations.module.scss` and `ReviewSection.module.scss` section to container

Before:

<img width="603" height="755" alt="Captura de pantalla 2025-09-25 a las 10 22 39" src="https://github.com/user-attachments/assets/ac00f88d-84d4-471a-aa8f-1343486e2bcd" />



After:

<img width="644" height="805" alt="Captura de pantalla 2025-09-25 a las 10 23 03" src="https://github.com/user-attachments/assets/b28ff2e2-7372-4e9a-a098-68731998d68f" />
