### PR TITLE
Fix: resize Recommendations pictures and delete Reviews margin-bottom

### DIFF
--- a/src/components/Recommendations/Recommendations.jsx
+++ b/src/components/Recommendations/Recommendations.jsx
@@ -100,20 +100,6 @@ const Recommendations = () => {
                 />
           ))}
         </div>
-        <div className={s.sliderBtnWrapper}>
-        <div className={s.navigation}>
-          <button
-            onClick={prevSlide}
-            className={`${s.arrow} ${s.buttonPrev}`}
-            title="Previous review"
-          ></button>
-          <button
-            onClick={nextSlide}
-            className={`${s.arrow} ${s.buttonNext}`}
-            title="Next review"
-          ></button>
-        </div>
-      </div>
       </div>
     </div>
   );

--- a/src/components/Recommendations/Recommendations.module.scss
+++ b/src/components/Recommendations/Recommendations.module.scss
@@ -1,21 +1,25 @@
 .recommendations {
   width: 100%;
-  margin:auto;
+  margin: auto;
+  --card-max-width: 16.875rem;
+  --card-aspect-ratio: 270 / 382;
   
   @media (min-width: 320px) {
-    width: 329px;
+    padding: 0 2rem;
     margin-bottom: 50px;
     margin-top: 50px;
   }
+
   @media (min-width: 600px) {
-    width: 100%;
-    padding: 1.6rem;
+    padding: 1.6rem 1rem;
     margin-bottom: 50px;
   }
+
   @media (min-width: 960px) {
     margin-top: 30px;
-    width: 100%;
+    padding: 1.6rem 0;
   }
+
   @media (min-width: 1280px) {
     padding-left: 0;
     padding-top: 50px;
@@ -28,55 +32,101 @@
   flex-direction: column;
   gap: 1rem;
 
+  @media (min-width: 960px) {
+
+  }
+
   @media (min-width: 1280px) {
     gap: 6rem;
     flex-direction: row;
+    align-items: flex-start;
   }
 }
 
 .sectionContent {
-  overflow: hidden; 
-
   display: flex;
-  flex-direction: row;
-  gap: 3.75rem;
+  width: 100%;
+  gap: 1.25rem;
+  overflow-x: auto;
+  overflow-y: visible;
+
+  scroll-snap-type: x mandatory; 
+  scroll-padding-inline: max(1rem, calc((100% - var(--card-max-width)) / 2));
+  -webkit-overflow-scrolling: touch;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 
   /* ≥ 600px */
   @media (min-width: 37.5em) {
     display: grid;
+    overflow: hidden;
+    scroll-snap-type: none;
     gap: 1.25rem;
     grid-template-columns: 1fr 1fr;
+    justify-items: center;
   }
 
   /* ≥ 960px */
   @media (min-width: 60em) {
     grid-template-columns: 1fr 1fr 1fr;
-    gap: 3.2rem;
+    gap: 8.2rem;
+    justify-items: start;
   }
 }
+
 
 .card {
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  width: 100%;
+  width: clamp(0rem, 100%, var(--card-max-width));
+  max-width: var(--card-max-width);
+  
+  margin-inline: 0;
+  flex: 0 0 clamp(0rem, 100%, var(--card-max-width));
+
+  @media (min-width: 37.5em) {
+    flex: none;
+    width: 100%;
+  }
+
+  @media (min-width: 60em) {
+    max-width: none;
+  }
+
+  @media (min-width: 80em) {
+    max-width: var(--card-max-width);
+  }
 
   picture {
-    height: 25rem;
     display: block;
+    width: 100%;
+
+    aspect-ratio: 1 / 1;
     overflow: hidden;
 
-    @media(min-width: 37.5em) {
-      height: auto;
+    @media (min-width: 37.5em) {
+      aspect-ratio: var(--card-aspect-ratio);
+    }
+
+    @media (min-width: 60em) {
+      &:hover {
+      transform: scale(1.02);
+      box-shadow: 0 4px 16px rgba(29, 57, 103, 0.2),
+                  inset 0 0 40px rgba(0, 0, 0, 0.3);
+      filter: brightness(0.95);
+      transition: all 0.3s ease;
+      }
     }
   }
 
   img {
+    display: block;
+    width: 100%;
     height: 100%;
-
-    @media(min-width: 37.5em) {
-      width: 100%;
-    }
+    object-fit: cover;
   }
 
   figcaption {

--- a/src/components/ReviewSlider/ReviewSection.module.scss
+++ b/src/components/ReviewSlider/ReviewSection.module.scss
@@ -5,7 +5,6 @@ $tablet: 48em; // ~768px
 
 .section {
   padding: 1rem 2rem;
-  margin-bottom: 3rem;
 
   display: flex;
   flex-direction: column;
@@ -16,6 +15,10 @@ $tablet: 48em; // ~768px
 
   @media (min-width: $tablet) {
     padding: 1rem 2rem;
+  }
+
+  @media (min-width: $smallScreen) {
+    padding: 1rem 0;
   }
 
   @media (min-width: $desktop) {


### PR DESCRIPTION
# Changes

- Resized Recommendations pictures in order to match the Figma aspect ratio for both desktop and mobile.
- Removed extra padding on laptop screens and added a smooth animation to align with other components' design decisions.
- Cleaned up unused buttons in `Recommendations.jsx`.
- Removed the `margin-bottom` in `ReviewsSection.jsx` so that only the `InstagramSection`’s `margin-top` defines the spacing.

