### PR TITLE
fix-the-menuBtn-hiding-after-clicking-on-it

### DIFF
--- a/src/components/header/Header.jsx
+++ b/src/components/header/Header.jsx
@@ -46,7 +46,6 @@ function Header() {
 
       <div className={s.iconsWrapper}>
         <Search onSearchToggle={handleSearchToggle} />
-        {!isNavOpen && (
           <button
             className={s.menuBtn}
             type="button"
@@ -60,7 +59,6 @@ function Header() {
               className={s.menuImg}
             />
           </button>
-        )}
       </div>
 
       <SideNavbar isOpen={isNavOpen} onClose={handleMenuClose} />


### PR DESCRIPTION
I just deleted the conditional rendering that the button menuBtn ( <button
              className={s.menuIcon}
              onClick={() => handleOpenAndCloseSideNavbar(0)}
              aria-label="menu"
            >) was inside it .