### PR TITLE
Fix menu btn disappearing

### DIFF
--- a/src/components/SideNavbar/SideNavbar.module.scss
+++ b/src/components/SideNavbar/SideNavbar.module.scss
@@ -59,6 +59,10 @@ $desktop: 90em; // 1280px
   transition: transform 0.35s ease, box-shadow 0.35s ease, visibility 0s linear 0.35s;
   will-change: transform;
 
+  scrollbar-width: none; /*Firefox*/
+  &::-webkit-scrollbar {
+  display: none; /* Chrome, Safari, Edge */
+}
   &--open {
     transform: translateY(0);
     box-shadow: 0 1.25rem 2.5rem rgba(0, 0, 0, 0.35);

--- a/src/components/header/Header.jsx
+++ b/src/components/header/Header.jsx
@@ -52,6 +52,7 @@ function Header() {
             type="button"
             onClick={handleMenuOpen}
             aria-label="Open navigation"
+            aria-hidden={isNavOpen ? "true" : "false"}
           >
             <img
               src={MenuIcon}

--- a/src/components/header/Header.jsx
+++ b/src/components/header/Header.jsx
@@ -46,9 +46,9 @@ function Header() {
 
       <div className={s.iconsWrapper}>
         <Search onSearchToggle={handleSearchToggle} />
-        {!isNavOpen && (
+        
           <button
-            className={s.menuBtn}
+            className={`${s.menuBtn} ${isNavOpen ? s['menuBtn--hidden'] : ''}`}
             type="button"
             onClick={handleMenuOpen}
             aria-label="Open navigation"
@@ -60,7 +60,7 @@ function Header() {
               className={s.menuImg}
             />
           </button>
-        )}
+        
       </div>
 
       <SideNavbar isOpen={isNavOpen} onClose={handleMenuClose} />

--- a/src/components/header/Header.module.scss
+++ b/src/components/header/Header.module.scss
@@ -54,6 +54,9 @@ $desktop: 80em;
   border: none;
   background: none;
 }
+.menuBtn--hidden {
+visibility: hidden;
+}
 
 .menuImg {
   width: 30px;
@@ -94,7 +97,4 @@ $desktop: 80em;
       pointer-events: none;
     }
 }
-}
-.menuBtn--hidden {
-visibility: hidden;
 }

--- a/src/components/header/Header.module.scss
+++ b/src/components/header/Header.module.scss
@@ -95,3 +95,6 @@ $desktop: 80em;
     }
 }
 }
+.menuBtn--hidden {
+visibility: hidden;
+}


### PR DESCRIPTION
adding a class to menuBtn , to keeps the button icon visible for visual consistency but hides it from screen readers (e.g., using aria-hidden="true" or visibility: hidden;). in that way, we can preserve the visual layout while still improving accessibility and navigation