### PR TITLE
Fix: adjust SideNavbar scrollbar to prevent layout shift

### DIFF
--- a/src/components/SideNavbar/SideNavbar.jsx
+++ b/src/components/SideNavbar/SideNavbar.jsx
@@ -219,22 +219,15 @@ function SideNavbar({ isOpen, onClose }) {
       return;
     }
 
-    const { style: bodyStyle } = document.body;
-    const { style: rootStyle } = document.documentElement;
-    const previous = {
-      bodyOverflow: bodyStyle.overflow,
-      bodyTouchAction: bodyStyle.touchAction,
-      rootOverflow: rootStyle.overflow,
-    };
+    const body = document.body;
+    const root = document.documentElement;
 
-    bodyStyle.overflow = "hidden";
-    bodyStyle.touchAction = "none";
-    rootStyle.overflow = "hidden";
+    body.classList.add("side-nav-lock");
+    root.classList.add("side-nav-lock");
 
     return () => {
-      bodyStyle.overflow = previous.bodyOverflow;
-      bodyStyle.touchAction = previous.bodyTouchAction;
-      rootStyle.overflow = previous.rootOverflow;
+      body.classList.remove("side-nav-lock");
+      root.classList.remove("side-nav-lock");
     };
   }, [isOpen]);
 

--- a/src/components/SideNavbar/SideNavbar.module.scss
+++ b/src/components/SideNavbar/SideNavbar.module.scss
@@ -8,6 +8,19 @@ $tablet: 37.5em; // 600px
 $laptop: 60em; // 960px
 $desktop: 90em; // 1280px
 
+:global(html) {
+  scrollbar-gutter: stable;
+}
+
+:global(html.side-nav-lock) {
+  overflow: hidden;
+}
+
+:global(body.side-nav-lock) {
+  overflow: hidden;
+  touch-action: none;
+}
+
 .overlay {
   position: fixed;
   inset: 0;
@@ -59,10 +72,6 @@ $desktop: 90em; // 1280px
   transition: transform 0.35s ease, box-shadow 0.35s ease, visibility 0s linear 0.35s;
   will-change: transform;
 
-  scrollbar-width: none; /*Firefox*/
-  &::-webkit-scrollbar {
-  display: none; /* Chrome, Safari, Edge */
-}
   &--open {
     transform: translateY(0);
     box-shadow: 0 1.25rem 2.5rem rgba(0, 0, 0, 0.35);


### PR DESCRIPTION
# Changes

- Replaced inline style manipulation with CSS class toggling.
- Moved scroll-lock logic to SCSS using `:global` selectors.
- Added `scrollbar-gutter: stable` property to prevent layout shift when the scrollbar disappears. 

 

https://github.com/user-attachments/assets/ad79a1bd-9482-45e5-9d2d-72a17847f339

