### PR TITLE
removing cursor pointer from pages in instagram section

### DIFF
--- a/src/components/FollowUs/FollowUs.module.scss
+++ b/src/components/FollowUs/FollowUs.module.scss
@@ -56,7 +56,6 @@
   height: 382px;
   object-fit: cover;
   transition: transform 0.3s ease, box-shadow 0.3s ease, filter 0.3s ease;
-  cursor: pointer;
 
   &:hover {
     transform: scale(1.02);


### PR DESCRIPTION
I just removed the cursor pointer from the pictures in instagram section , becouse they are not removable anymore.