### PR TITLE
fix: hide buttons and social media icons on mobile and tablet viewports

### DIFF
--- a/src/components/header/Header.module.scss
+++ b/src/components/header/Header.module.scss
@@ -58,10 +58,10 @@ $desktop: 80em;
 }
 
 .btnCorrection {
-  display: none;
+  display: none !important; // Workaround: it should be fix asap.
 
   @media (min-width: 43.75em) {
-    display: flex;
+    display: flex !important; // Workaround: it should be fix asap.
     font-size: 0.8rem;
     min-inline-size: 11.25rem;
     inline-size: auto;

--- a/src/views/HomePage/HomeHeader.jsx
+++ b/src/views/HomePage/HomeHeader.jsx
@@ -172,7 +172,7 @@ const useStyles = makeStyles((theme) => ({
     alignItems: "center",
     gap: "16px",
     paddingTop: "12px",
-    [theme.breakpoints.down("sm")]: {
+    "@media (max-width: 959px)": {
       display: "none",
     },
   },


### PR DESCRIPTION
#Summary

This PR provides an urgent fix for some minor CSS conflicts introduced during the migration. 
