### PR TITLE
Fix: add side padding to mobile and tablet viewports

### DIFF
--- a/src/Styles/App.css
+++ b/src/Styles/App.css
@@ -4,7 +4,7 @@
 :root {
   /*Breakpoints values*/
   --tablet: 768px;
-  --laptop: 960px;
+  --small-screen: 960px;
   --desktop: 1280px;
 
   /* Brand colors: CTA's active and focused states */

--- a/src/components/Layout/Layout.module.scss
+++ b/src/components/Layout/Layout.module.scss
@@ -1,5 +1,5 @@
-$tablet: 37.5em;
-$laptop: 60em;
+$tablet: 48em;
+$small-screen: 60em;
 $desktop: 90em;
 
 .container {
@@ -8,6 +8,15 @@ $desktop: 90em;
   align-items: center;
   max-width: 72rem; // 1152px
   margin: auto;
+  padding: 0 1rem;
+
+  @media (min-width: $tablet) {
+    padding: 0 2rem;
+  }
+
+  @media (min-width: $desktop) {
+    padding: 0;
+  }
 }
 
 .outlet {

--- a/src/views/HomePage/CaruselSliderHome/CaruselSliderHome.module.scss
+++ b/src/views/HomePage/CaruselSliderHome/CaruselSliderHome.module.scss
@@ -1,5 +1,5 @@
-$tablet: 37.5em; // 600px
-$laptop: 60em; // 960px
+$tablet: 48em; // 768px
+$small-screen: 60em; // 960px
 $desktop: 80em; // 1280px
 
 /* --- Base hero layout --- */
@@ -9,11 +9,19 @@ $desktop: 80em; // 1280px
   display: flex;
   justify-content: center;
   align-items: flex-end;
-  width: 100%;
+  width: 100vw;
+  margin-left: calc(50% - 50vw);
+  margin-right: calc(50% - 50vw);
   aspect-ratio: 375 / 300; // Figma's aspect ratio for mobile
 
   @media (min-width: $tablet) {
     aspect-ratio: 1054 / 556; // Figma's aspect ratio standard
+  }
+
+  @media (min-width: $small-screen) {
+    width: 100%;
+    margin-left: 0;
+    margin-right: 0;
   }
 }
 
@@ -39,11 +47,11 @@ $desktop: 80em; // 1280px
   bottom: 12px;
   margin-bottom: 0;
 
-  @media (min-width: 600px) {
+  @media (min-width: var(--tablet)) {
     bottom: 14px;
   }
 
-  @media (min-width: 960px) {
+  @media (min-width: var(--small-screen)) {
     bottom: 16px;
   }
 }


### PR DESCRIPTION
# Summary 

This PR introduces side padding in Layout for mobile and tablet viewports.

## Changes

- Added side padding in `Layout.jsx`: `1rem` for mobile viewport and `2rem` for tablet.
- Updated `CarouselSlideHome.jsx` to occupy the full viewport width (100vw) on mobile and tablet. 

### Note:
- Some components (such as Blog and Reviews) still need a padding review to fully align with the new design once they are refactored for mobile and tablet viewports.