### PR TITLE
Style footer responsive

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,7 +3,7 @@ import { lazy, Suspense, useMemo, useState } from "react";
 import { HelmetProvider, Helmet } from "react-helmet-async";
 import { Route, Routes } from "react-router-dom";
 
-import "./Styles/App.css";
+import "./Styles/App.scss";
 import EnquirePage from "./components/BookingPage/EnquirePage.jsx";
 import { RedirectBlog, RedirectTripAdv } from "./components/helpers/redirect/Redirect.jsx";
 import combinedSchema from "./components/helpers/SchemaOrg/schema.js";

--- a/src/Styles/App.scss
+++ b/src/Styles/App.scss
@@ -1,12 +1,12 @@
 @import url("https://fonts.googleapis.com/css2?family=Josefin+Sans:wght@100;200;300;400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=Maven+Pro:wght@400;500;600;700;800;900&display=swap");
 
-:root {
-  /*Breakpoints values*/
-  --tablet: 768px;
-  --small-screen: 960px;
-  --desktop: 1280px;
+/*Breakpoints values*/
+$tablet: 768px;
+$smallScreen: 960px;
+$desktop: 1280px;
 
+:root {
   /* Brand colors: CTA's active and focused states */
   --color-primary-100: #edf1f4;
   --color-primary-200: #cdd7e2;

--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -131,11 +131,11 @@ function Footer() {
             <SiteMapMinimal title="social media" data={footerSections.social} />
           </>
         ) : (
-          <>
+          <div className={s.siteMapContainer}>
             <SiteMap title="social media" data={footerSections.social} />
             <SiteMap title="blue house" data={footerSections.blueHouse} />
             <SiteMap title="contact us" data={footerSections.contact} />
-          </>
+          </div>
         )}
       </div>
 

--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -124,7 +124,7 @@ function Footer() {
           <img src={logoBadge} alt="Blue House Home" />
         </Link>
 
-        {isMobile || isTablet ? (
+        {isMobile ? (
           <>
             <SiteMap title="blue house" data={footerSections.blueHouse} />
             <SiteMap title="contact us" data={footerSections.contact} />

--- a/src/components/Footer/Footer.module.scss
+++ b/src/components/Footer/Footer.module.scss
@@ -6,9 +6,8 @@
   flex-direction: column;
   align-items: center;
   gap: 2.5rem;
-
+  padding: 0;
   margin-bottom: 2.5rem;
-  padding: 0 1rem;
 
   @media (min-width: app.$smallScreen) {
     align-items: stretch;
@@ -21,16 +20,10 @@
   gap: 1.5rem;
   align-items: center;
   width: 100%;
-
   @media (min-width: app.$tablet) {
     flex-direction: row;
     justify-content: space-between;
     align-items: stretch;
-    width: auto;
-    gap: 2rem;
-  }
-  @media (min-width: app.$smallScreen) {
-    flex-wrap: wrap;
   }
 }
 
@@ -60,15 +53,15 @@
   align-items: center;
   text-align: center;
   gap: 1.25rem;
+  border: 1px solid red;
+  @media (min-width: app.$tablet) {
+    align-items: flex-start;
+  }
 
   @media (min-width: app.$smallScreen) {
     flex-direction: row;
-    align-items: flex-start;
     gap: 1.5rem;
     text-align: left;
-  }
-  @media (min-width: app.$tablet) {
-    align-items: flex-start;
   }
 
   h3 {
@@ -95,12 +88,12 @@
     flex-direction: column;
     gap: 1rem;
     align-items: center;
-
     @media (min-width: app.$tablet) {
       align-items: flex-start;
       margin: 0;
       padding: 0;
       gap: 0.75rem;
+      max-width: 24vw; //limit the width in tablet so text doesn't stretch too much
     }
   }
 }

--- a/src/components/Footer/Footer.module.scss
+++ b/src/components/Footer/Footer.module.scss
@@ -1,7 +1,4 @@
-// Media Queries variables
-$desktop: 80em; // ~1280px
-$laptop: 60em; // ~960px
-$tablet: 48em; // ~768px
+@use "../../Styles/App.scss" as app;
 
 .footer {
   width: 100%;
@@ -13,7 +10,7 @@ $tablet: 48em; // ~768px
   margin-bottom: 2.5rem;
   padding: 0 1rem;
 
-  @media (min-width: $laptop) {
+  @media (min-width: app.$smallScreen) {
     align-items: stretch;
   }
 }
@@ -25,7 +22,7 @@ $tablet: 48em; // ~768px
   align-items: center;
   width: 100%;
 
-  @media (min-width: $laptop) {
+  @media (min-width: app.$tablet) {
     flex-direction: row;
     justify-content: space-between;
     flex-wrap: wrap;
@@ -63,7 +60,7 @@ $tablet: 48em; // ~768px
   text-align: center;
   gap: 0.5rem;
 
-  @media (min-width: $laptop) {
+  @media (min-width: app.$smallScreen) {
     flex-direction: row;
     align-items: flex-start;
     gap: 1.5rem;
@@ -78,7 +75,7 @@ $tablet: 48em; // ~768px
     white-space: nowrap;
     color: var(--color-primary-500);
 
-    @media (min-width: $laptop) {
+    @media (min-width: app.$smallScreen) {
       writing-mode: vertical-rl;
       text-orientation: sideways;
       transform: rotate(180deg);
@@ -94,7 +91,7 @@ $tablet: 48em; // ~768px
     gap: 0.75rem;
     align-items: center;
 
-    @media (min-width: $laptop) {
+    @media (min-width: app.$smallScreen) {
       align-items: flex-start;
     }
   }
@@ -138,7 +135,7 @@ $tablet: 48em; // ~768px
     color 0.2s ease,
     text-decoration-color 0.2s ease;
 
-  @media (min-width: $laptop) {
+  @media (min-width: app.$smallScreen) {
     flex-direction: row;
     justify-content: flex-start;
     align-items: flex-start;
@@ -148,7 +145,7 @@ $tablet: 48em; // ~768px
 }
 
 .addressText {
-  @media (min-width: $laptop) {
+  @media (min-width: app.$smallScreen) {
     display: block;
     text-align: left;
     line-height: 1.4;
@@ -185,7 +182,7 @@ $tablet: 48em; // ~768px
   font-size: 0.8rem;
   font-weight: 200;
 
-  @media (min-width: $laptop) {
+  @media (min-width: app.$smallScreen) {
     font-size: 1rem;
     gap: 0.5rem;
   }
@@ -194,7 +191,7 @@ $tablet: 48em; // ~768px
 .gapSm {
   gap: 0.2rem;
 
-  @media (min-width: $laptop) {
+  @media (min-width: app.$smallScreen) {
     gap: 0.5rem;
   }
 }
@@ -202,7 +199,7 @@ $tablet: 48em; // ~768px
 .gapMd {
   gap: 0.5rem;
 
-  @media (min-width: $laptop) {
+  @media (min-width: app.$smallScreen) {
     gap: 1rem;
   }
 }

--- a/src/components/Footer/Footer.module.scss
+++ b/src/components/Footer/Footer.module.scss
@@ -22,8 +22,36 @@
   width: 100%;
   @media (min-width: app.$tablet) {
     flex-direction: row;
+    justify-content: space-evenly;
+    align-items: stretch;
+    gap: 1.25rem;
+    width: 704px;
+  }
+  @media (min-width: app.$smallScreen) {
+    width: 100%;
+    max-width: none;
+    gap: 10vw; //use vw isntead of rem for better scaling between breakpoints designs
+  }
+  @media (min-width: app.$desktop) {
+    gap: 8.75rem;
+  }
+}
+.siteMapContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+  width: 100%;
+  @media (min-width: app.$tablet) {
+    flex-direction: row;
     justify-content: space-between;
     align-items: stretch;
+    padding-right: 1rem;
+  }
+  @media (min-width: app.$smallScreen) {
+    flex: 1;
+    padding: 0;
+    justify-content: space-between;
   }
 }
 
@@ -53,7 +81,6 @@
   align-items: center;
   text-align: center;
   gap: 1.25rem;
-  border: 1px solid red;
   @media (min-width: app.$tablet) {
     align-items: flex-start;
   }
@@ -93,7 +120,10 @@
       margin: 0;
       padding: 0;
       gap: 0.75rem;
-      max-width: 24vw; //limit the width in tablet so text doesn't stretch too much
+      max-width: 180px;
+    }
+    @media (min-width: app.$smallScreen) {
+      max-width: none;
     }
   }
 }

--- a/src/components/Footer/Footer.module.scss
+++ b/src/components/Footer/Footer.module.scss
@@ -18,16 +18,19 @@
 .linkWrapper {
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: 1.5rem;
   align-items: center;
   width: 100%;
 
   @media (min-width: app.$tablet) {
     flex-direction: row;
     justify-content: space-between;
-    flex-wrap: wrap;
     align-items: stretch;
     width: auto;
+    gap: 2rem;
+  }
+  @media (min-width: app.$smallScreen) {
+    flex-wrap: wrap;
   }
 }
 
@@ -35,8 +38,8 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 60px;
-  height: 60px;
+  width: 55px;
+  height: 55px;
   border-radius: 50%;
   transition: transform 0.2s ease;
 
@@ -45,8 +48,6 @@
   }
 
   img {
-    width: 100%;
-    height: 100%;
     object-fit: contain;
   }
 }
@@ -58,13 +59,16 @@
   flex-direction: column;
   align-items: center;
   text-align: center;
-  gap: 0.5rem;
+  gap: 1.25rem;
 
   @media (min-width: app.$smallScreen) {
     flex-direction: row;
     align-items: flex-start;
     gap: 1.5rem;
     text-align: left;
+  }
+  @media (min-width: app.$tablet) {
+    align-items: flex-start;
   }
 
   h3 {
@@ -74,7 +78,7 @@
     text-transform: uppercase;
     white-space: nowrap;
     color: var(--color-primary-500);
-
+    margin: 0;
     @media (min-width: app.$smallScreen) {
       writing-mode: vertical-rl;
       text-orientation: sideways;
@@ -85,14 +89,18 @@
   ul {
     list-style: none;
     margin: 0;
-    padding: 0;
+    margin-bottom: 0.5rem; //space between last link from one column to the next --mobile only
+    padding: 0 1rem; //makes the address break lines correctly --mobile only
     display: flex;
     flex-direction: column;
-    gap: 0.75rem;
+    gap: 1rem;
     align-items: center;
 
-    @media (min-width: app.$smallScreen) {
+    @media (min-width: app.$tablet) {
       align-items: flex-start;
+      margin: 0;
+      padding: 0;
+      gap: 0.75rem;
     }
   }
 }
@@ -135,7 +143,7 @@
     color 0.2s ease,
     text-decoration-color 0.2s ease;
 
-  @media (min-width: app.$smallScreen) {
+  @media (min-width: app.$tablet) {
     flex-direction: row;
     justify-content: flex-start;
     align-items: flex-start;

--- a/src/components/Footer/footerData.js
+++ b/src/components/Footer/footerData.js
@@ -70,7 +70,7 @@ const BLUE_HOUSE_LINKS = Object.freeze([
     id: "support",
     name: "Support",
     type: "external",
-    href: "https://gnl.ladesk.com/219394-Feedback",
+    href: "https://bluehouseis.zohodesk.eu/portal/en/newticket?departmentId=135604000000205173&layoutId=135604000000214460",
     newTab: true,
   },
   {

--- a/src/components/Footer/footerData.js
+++ b/src/components/Footer/footerData.js
@@ -30,7 +30,7 @@ const SOCIAL_LINKS = Object.freeze([
     icon: XIcon,
     type: "external",
     //removed twitter link since the account is not active and changed newTab to false so it wont open a new tab when clicked
-    href: "#",
+    to: "/",
     newTab: false,
   },
   {


### PR DESCRIPTION
## Summary
This PR changes a KEY file extension, the App.***css*** to App.***scss***, adds breakpoint variables to it, and also styles the footer section as indicated in the Figma mockup for all breakpoints

# Changes
The change from App.css to App.scss allows us to create variables like this:
<img width="186" height="100" alt="image" src="https://github.com/user-attachments/assets/dddd916c-38e1-4e27-aeba-72400b806c99" />

You should import them as follows:
<img width="309" height="41" alt="image" src="https://github.com/user-attachments/assets/654f7350-b5aa-4eb6-a751-c40355de005d" />

And use them like this :
<img width="304" height="35" alt="image" src="https://github.com/user-attachments/assets/2a578d22-90eb-47ed-9fb8-1ad884c119a4" />

**The main change in the breakpoints is the addition of 768px for the tablet breakpoint, aligning with said default size in Figma.**

# Style
The footer is now as on the Figma mockup across all the breakpoints. 
- The order of the columns has been changed since mobile and tablet shared the same order and the design shows that tablet shares the same order as desktop instead.
- Added a div to wrap these elements for easy styling

> 