### PR TITLE
Style cookie buttons with blue/white theme and hover effects

### DIFF
--- a/src/components/CookiesBanner/CookiesBanner.jsx
+++ b/src/components/CookiesBanner/CookiesBanner.jsx
@@ -74,7 +74,9 @@ function CookiesBanner() {
     Cookies.set("cookiesPermation", choice);
     setDisplay("none");
   };
-  const { root, cookiesDescription, coockieTitle, actions, moreInfo } = useStyles({ display });
+  const { root, cookiesDescription, coockieTitle, actions, moreInfo, declineBtn } = useStyles({
+    display,
+  });
 
   if (display === "none") {
     return null;
@@ -140,7 +142,7 @@ function CookiesBanner() {
         <Button
           handleClick={() => handleAcceptingAndDeclineCookies(false)}
           text="DECLINE COOKIES"
-          btnClass="btnDark"
+          btnClass="btnLight"
           width={isMobile ? "100px" : "200px"}
         />
         <ManagePreferences />

--- a/src/components/Shared/Button/Button.module.scss
+++ b/src/components/Shared/Button/Button.module.scss
@@ -76,7 +76,7 @@
   color: #14202b;
   text-transform: uppercase;
   transition: all 0.3s ease;
-  border: 1px solid #3b5998;
+  border: 1px solid #1d3967;
   outline: none;
   cursor: pointer;
 
@@ -87,7 +87,7 @@
 
 .btnLight:hover {
   color: #fff;
-  background-color: #3b5998;
+  background-color: #1d3967;
   outline: none;
 }
 


### PR DESCRIPTION
Changed cookie consent buttons styling:
- Accept button: blue background, white on hover
- Decline button: white background, blue on hover
Also in Button.module.scss I changed the .btnLight to the actual blue color and use it inside the decline button classes