### PR TITLE
Fix spacing and style issues in review/support section

### DIFF
--- a/src/components/SuportComponent/Support.module.scss
+++ b/src/components/SuportComponent/Support.module.scss
@@ -9,6 +9,7 @@
     padding: 0 20px;
     margin: 0 0 7.37rem 0;
   }
+
   @media (min-width: 1280px) {
     padding: 0;
   }
@@ -20,6 +21,7 @@
   align-items: center;
   width: 100%;
   gap: 20px;
+  margin-top: 3.75rem;
 
   @media (min-width: 600px) {
     width: 100%;
@@ -27,6 +29,7 @@
     flex-direction: row;
     flex-wrap: wrap;
   }
+
   @media (min-width: 960px) {
     justify-content: space-between;
     align-items: stretch;
@@ -53,12 +56,15 @@
   @media (min-width: 320px) and (max-width: 599.99px) {
     width: 80%;
   }
+
   @media (min-width: 600px) and (max-width: 959.99px) {
     width: 48%;
   }
+
   @media (min-width: 960px) and (max-width: 1279.99px) {
     width: calc(25% - 18px);
   }
+
   @media (min-width: 1280px) and (max-width: 2200px) {
     width: 270px;
   }
@@ -77,12 +83,15 @@
   @media (min-width: 320px) and (max-width: 599.99px) {
     padding: 20px 10px;
   }
+
   @media (min-width: 600px) and (max-width: 959.99px) {
     padding: 20px 10px;
   }
+
   @media (min-width: 960px) and (max-width: 1279.99px) {
     padding: 24px 16px;
   }
+
   @media (min-width: 1280px) and (max-width: 2200px) {
     padding: 24px 16px;
   }
@@ -111,6 +120,7 @@
   @media (min-width: 600px) and (max-width: 959.99px) {
     margin-bottom: 0;
   }
+
   @media (min-width: 960px) and (max-width: 1280px) {
     margin-bottom: 5px;
   }


### PR DESCRIPTION
Improved spacing and styling in the review/support section for better UI consistency.

**Before**

<img width="1238" height="524" alt="image (1)" src="https://github.com/user-attachments/assets/79b714af-6fea-42e9-bb2d-35c59bfad550" />

**After**

![Screenshot 2025-12-14 221650](https://github.com/user-attachments/assets/22473ce1-5875-4748-a4e6-beca74f7c0dd)

