### PR TITLE
Chore: rename useBreakpointsNew to useBreakpoints

### DIFF
--- a/src/Styles/useBreakpoints.js
+++ b/src/Styles/useBreakpoints.js
@@ -8,7 +8,7 @@ const BREAKPOINTS = [
 
 const getBreakpointName = (matches) => matches.find((match) => match.matches)?.name ?? "mobile";
 
-const useBreakpointsNew = () => {
+const useBreakpoints = () => {
   const isClient = typeof window !== "undefined";
   const mediaList = useRef([]);
   const listeners = useRef(new Map());
@@ -66,4 +66,4 @@ const useBreakpointsNew = () => {
   );
 };
 
-export default useBreakpointsNew;
+export default useBreakpoints;

--- a/src/components/AboutPageComponent/AboutPageComponent.jsx
+++ b/src/components/AboutPageComponent/AboutPageComponent.jsx
@@ -1,6 +1,6 @@
 import s from "./AboutPageComponent.module.scss";
 import signature from "../../images/aboutus/signature.png";
-import useBreakpoints from "../../Styles/useBreakpointsNew.js";
+import useBreakpoints from "../../Styles/useBreakpoints.js";
 import { WithTransLate } from "../helpers/translating/index.jsx";
 import NewMap from "../map/NewMap.jsx";
 

--- a/src/components/AdditionalServices/AdditionalServices.jsx
+++ b/src/components/AdditionalServices/AdditionalServices.jsx
@@ -3,7 +3,7 @@ import addservices01 from "../../images/roombooking/add_services/add_services01.
 import addservices02 from "../../images/roombooking/add_services/add_services02.webp";
 import addservices03 from "../../images/roombooking/add_services/add_services03.webp";
 import addservices04 from "../../images/roombooking/add_services/add_services04.webp";
-import useBreakpoints from "../../Styles/useBreakpointsNew.js";
+import useBreakpoints from "../../Styles/useBreakpoints.js";
 import { WithTransLate } from "../helpers/translating/index.jsx";
 
 const AdditionalServices = () => {

--- a/src/components/BlogComponent/Blog.jsx
+++ b/src/components/BlogComponent/Blog.jsx
@@ -1,6 +1,6 @@
 import s from "./BlogPart.module.scss";
 import blogHero from "../../images/Blog/BlogSection.png";
-import useBreakpoints from "../../Styles/useBreakpointsNew.js";
+import useBreakpoints from "../../Styles/useBreakpoints.js";
 import { WithTransLate } from "../helpers/translating";
 import Link from "../Shared/ui/Link.jsx";
 

--- a/src/components/CookiesBanner/CookiesBanner.jsx
+++ b/src/components/CookiesBanner/CookiesBanner.jsx
@@ -3,7 +3,7 @@ import Cookies from "js-cookie";
 import { useState } from "react";
 
 import ManagePreferences from "./ManagePreferences.jsx";
-import useBreakpoints from "../../Styles/useBreakpointsNew.js";
+import useBreakpoints from "../../Styles/useBreakpoints.js";
 import { WithTransLate } from "../helpers/translating/index.jsx";
 import Button from "../Shared/Button/Button.jsx";
 

--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -4,7 +4,7 @@ import { Link } from "react-router-dom";
 import s from "./Footer.module.scss";
 import { footerSections } from "./footerData.js";
 import logoBadge from "../../images/footer/logo-blue.svg";
-import useBreakpoints from "../../Styles/useBreakpointsNew.js";
+import useBreakpoints from "../../Styles/useBreakpoints.js";
 import { WithTransLate } from "../helpers/translating";
 import IconButton from "../Shared/ui/IconButton.jsx";
 

--- a/src/components/Layout/Layout.jsx
+++ b/src/components/Layout/Layout.jsx
@@ -1,14 +1,14 @@
 import { Outlet } from "react-router-dom";
 
 import s from "./Layout.module.scss";
-import useBreakpointsNew from "../../Styles/useBreakpointsNew.js";
+import useBreakpoints from "../../Styles/useBreakpoints.js";
 import CookiesBanner from "../CookiesBanner/CookiesBanner.jsx";
 import Footer from "../Footer/Footer.jsx";
 import Header from "../header/Header.jsx";
 import NewMap from "../map/NewMap.jsx";
 
 function Layout() {
-  const { isSmallScreen, isDesktop } = useBreakpointsNew();
+  const { isSmallScreen, isDesktop } = useBreakpoints();
 
   return (
     <div className={s.container}>

--- a/src/components/OurServices/OurServices.jsx
+++ b/src/components/OurServices/OurServices.jsx
@@ -2,7 +2,7 @@ import s from "./OurServices.module.scss";
 import clock from "../../images/services/clock.svg";
 import house from "../../images/services/house.svg";
 import money from "../../images/services/money.svg";
-import useBreakpoints from "../../Styles/useBreakpointsNew.js";
+import useBreakpoints from "../../Styles/useBreakpoints.js";
 import { WithTransLate } from "../helpers/translating/index.jsx";
 
 // Titles + subtitles exactly as in the design

--- a/src/components/PaymentComponent/DayTours/DayTours.jsx
+++ b/src/components/PaymentComponent/DayTours/DayTours.jsx
@@ -3,7 +3,7 @@ import addservices01 from "../../../images/roombooking/add_services/add_services
 import addservices04 from "../../../images/roombooking/add_services/add_services04.webp";
 import addservices03 from "../../../images/roombooking/add_services/Countryside_tours.webp";
 import addservices02 from "../../../images/roombooking/add_services/Reykjavik_Daytours.webp";
-import useBreakpoints from "../../../Styles/useBreakpointsNew.js";
+import useBreakpoints from "../../../Styles/useBreakpoints.js";
 import { WithTransLate } from "../../helpers/translating/index.jsx";
 
 const DayTours = () => {

--- a/src/components/PaymentComponent/PaymentComponent.jsx
+++ b/src/components/PaymentComponent/PaymentComponent.jsx
@@ -13,7 +13,7 @@ import {
   getBookingConfirmed,
 } from "../../redux/technitial/technical-selectors.js";
 import { setPaymentStage } from "../../redux/technitial/technical-slice.js";
-import useBreakpoints from "../../Styles/useBreakpointsNew.js";
+import useBreakpoints from "../../Styles/useBreakpoints.js";
 import { WithTransLate } from "../helpers/translating";
 import Button from "../Shared/Button/Button.jsx";
 

--- a/src/components/PaymentComponent/PriceSummaryPart/PriceSummaryPart.jsx
+++ b/src/components/PaymentComponent/PriceSummaryPart/PriceSummaryPart.jsx
@@ -11,7 +11,7 @@ import {
   getTotalAmountCurrency,
 } from "../../../redux/dataSearch/dataSearch-selectors.js";
 import { setCurrency, setExchangeRate } from "../../../redux/dataSearch/dataSearch-slice.js";
-import useBreakpoints from "../../../Styles/useBreakpointsNew.js";
+import useBreakpoints from "../../../Styles/useBreakpoints.js";
 import { WithTransLate } from "../../helpers/translating";
 
 const PriceSummaryPart = () => {

--- a/src/components/PhotoGallery/MobileGallerySection/Galary.jsx
+++ b/src/components/PhotoGallery/MobileGallerySection/Galary.jsx
@@ -11,7 +11,7 @@ import * as React from "react";
 
 import { Rooms, Houses, Surroundings } from "./Galary-information.js";
 import ImageSlider from "./ImageSlider/ImageSlider.jsx";
-import useBreakpoints from "../../../Styles/useBreakpointsNew.js";
+import useBreakpoints from "../../../Styles/useBreakpoints.js";
 import { WithTransLate } from "../../helpers/translating";
 
 function CustomTabPanel(props) {

--- a/src/components/Recommendations/Recommendations.jsx
+++ b/src/components/Recommendations/Recommendations.jsx
@@ -9,7 +9,7 @@ import gc from "../../images/RECOMMENDATIONS/Glacier-Caves.webp";
 import gcd from "../../images/RECOMMENDATIONS/Glacier-Caves01.webp";
 import nl from "../../images/RECOMMENDATIONS/Northernlights.webp";
 import nld from "../../images/RECOMMENDATIONS/Northernlights01.webp";
-import useBreakpoints from "../../Styles/useBreakpointsNew.js";
+import useBreakpoints from "../../Styles/useBreakpoints.js";
 import { WithTransLate } from "../helpers/translating/index.jsx";
 
 function Card({ title, imageSrc, description }) {

--- a/src/components/ServicesRoom/ServicesRoom.jsx
+++ b/src/components/ServicesRoom/ServicesRoom.jsx
@@ -7,7 +7,7 @@ import SliderPreviewPhoto from "./SliderPreviewPhoto/SliderPreviewPhoto.jsx";
 import SliderPreviewPhotoM from "./SliderPreviewPhotoM/SliderPreviewPhotoM.jsx";
 import { WithTransLate } from "..//helpers/translating/index.jsx";
 import { getDayDifference, getAddParams } from "../../redux/dataSearch/dataSearch-selectors.js";
-import useBreakpoints from "../../Styles/useBreakpointsNew.js";
+import useBreakpoints from "../../Styles/useBreakpoints.js";
 import Button from "../Shared/Button/Button.jsx";
 
 const ServicesRoom = () => {

--- a/src/components/Shared/SliderSlick/SliderSlick.jsx
+++ b/src/components/Shared/SliderSlick/SliderSlick.jsx
@@ -5,7 +5,7 @@ import "slick-carousel/slick/slick.css";
 import "slick-carousel/slick/slick-theme.css";
 
 import s from "./SliderSlick.module.scss";
-import useBreakpoints from "../../../Styles/useBreakpointsNew.js";
+import useBreakpoints from "../../../Styles/useBreakpoints.js";
 
 const PhotoSlider = ({ photos, width = "100%", height = "auto" }) => {
   const { isSmallScreen, isDesktop } = useBreakpoints();

--- a/src/components/header/Header.jsx
+++ b/src/components/header/Header.jsx
@@ -5,7 +5,7 @@ import s from "./Header.module.scss";
 import Search from "./Search.jsx";
 import logo from "../../images/logo.svg";
 import MenuIcon from "../../images/MenuIcon_Header.svg";
-import useBreakpoints from "../../Styles/useBreakpointsNew.js";
+import useBreakpoints from "../../Styles/useBreakpoints.js";
 import { WithTransLate } from "../helpers/translating/index.jsx";
 import LinkButton from "../Shared/ui/Link.jsx";
 import SideNavbar from "../SideNavbar/SideNavbar.jsx";

--- a/src/components/header/Search.jsx
+++ b/src/components/header/Search.jsx
@@ -6,7 +6,7 @@ import keywords from "./keywords.json";
 import s from "../../components/header/search.module.scss";
 import CloseIcon from "../../images/close-white.svg";
 import SearchIcon from "../../images/SearchIcon_Header.svg";
-import useBreakpoints from "../../Styles/useBreakpointsNew.js";
+import useBreakpoints from "../../Styles/useBreakpoints.js";
 
 export default function Search({ onSearchToggle }) {
   const [open, setOpen] = useState(false);

--- a/src/components/map/NewMap.jsx
+++ b/src/components/map/NewMap.jsx
@@ -2,7 +2,7 @@ import { useState, useRef, useEffect } from "react";
 import { FiMaximize, FiX } from "react-icons/fi";
 
 import WeatherCard from "./WeatherCard.jsx";
-import useBreakpoints from "../../Styles/useBreakpointsNew.js";
+import useBreakpoints from "../../Styles/useBreakpoints.js";
 import "./WeatherMap.css";
 
 const NewMap = () => {

--- a/src/views/HomePage/HomePage.jsx
+++ b/src/views/HomePage/HomePage.jsx
@@ -13,7 +13,7 @@ import Support from "../../components/SuportComponent/support.jsx";
 import housesImage from "../../images/gallery/houseBB2.svg";
 import roomsImage from "../../images/gallery/rooms.svg";
 import surroundingsImage from "../../images/gallery/surroundings.svg";
-import useBreakpoints from "../../Styles/useBreakpointsNew.js";
+import useBreakpoints from "../../Styles/useBreakpoints.js";
 
 const GALLERY_BACKGROUND_IMAGES_AND_TITLES = [
   { background: roomsImage, title: "Rooms" },

--- a/src/views/RoomDetails/PartDetails/PartDetails.jsx
+++ b/src/views/RoomDetails/PartDetails/PartDetails.jsx
@@ -16,7 +16,7 @@ import {
   setPricePerNight,
   setPaymentType,
 } from "../../../redux/dataSearch/dataSearch-slice.js";
-import useBreakpoints from "../../../Styles/useBreakpointsNew.js";
+import useBreakpoints from "../../../Styles/useBreakpoints.js";
 import Advantages from "../Advantages/Advantages.jsx";
 
 const PartDetails = ({ data }) => {

--- a/src/views/RoomDetails/RoomDetails.jsx
+++ b/src/views/RoomDetails/RoomDetails.jsx
@@ -13,7 +13,7 @@ import Button from "../../components/Shared/Button/Button.jsx";
 import PhotoSlider from "../../components/Shared/SliderSlick/SliderSlick.jsx";
 import Support from "../../components/SuportComponent/support.jsx";
 import { setPaymentStage } from "../../redux/technitial/technical-slice.js";
-import useBreakpoints from "../../Styles/useBreakpointsNew.js";
+import useBreakpoints from "../../Styles/useBreakpoints.js";
 
 const RoomDetails = () => {
   const { room } = useParams();

--- a/src/views/roombooking/Advantages.jsx
+++ b/src/views/roombooking/Advantages.jsx
@@ -6,7 +6,7 @@ import planeSign from "../../images/roombooking/planeSign.svg";
 import spotSign from "../../images/roombooking/spotSign.svg";
 import timeSign from "../../images/roombooking/timeSign.svg";
 import wifiSign from "../../images/roombooking/wifiSign.svg";
-import useBreakpoints from "../../Styles/useBreakpointsNew.js";
+import useBreakpoints from "../../Styles/useBreakpoints.js";
 
 const Advantages = () => {
   const { isMobile } = useBreakpoints();

--- a/src/views/roombooking/RoomBooking.jsx
+++ b/src/views/roombooking/RoomBooking.jsx
@@ -9,7 +9,7 @@ import ReviewRoomBooking from "../../components/ReviewRoomBooking/ReviewRoomBook
 import ServicesRoom from "../../components/ServicesRoom/ServicesRoom.jsx";
 import Support from "../../components/SuportComponent/support.jsx";
 import { getRoomsData } from "../../redux/technitial/technical-operations.js";
-import useBreakpoints from "../../Styles/useBreakpointsNew.js";
+import useBreakpoints from "../../Styles/useBreakpoints.js";
 import "./index.css";
 
 export const googleRatings = [


### PR DESCRIPTION
## Summary

This PR renames the `useBreakpointsNew` hook to `useBreakpoints` and updates all imports across the codebase to reflect this change.

## Changes

- Renamed the function from `useBreakpointsNew` to `useBreakpoints`.
- Updated the default export.
- Updated import paths from `useBreakpointsNew.js` to `useBreakpoints.js`.
- Removed references to `useBreakpointsNew` from the codebase

This change is a pure refactoring with no functional modifications. The hook's API and behavior remain unchanged. All existing usages continue to work as before.