### PR TITLE
feat: add HeaderOnlyLayout component for pages displaying only a header

### DIFF
--- a/src/components/Layout/HeaderOnlyLayout.jsx
+++ b/src/components/Layout/HeaderOnlyLayout.jsx
@@ -3,15 +3,13 @@ import { Outlet } from "react-router-dom";
 import s from "./Layout.module.scss";
 import Header from "../header/Header.jsx";
 
-function HeaderOnlyLayout() {
+function HeaderOnlyLayout({ children }) {
   return (
     <>
       <div className={s.header}>
         <Header />
       </div>
-      <div className={s.outlet}>
-        <Outlet />
-      </div>
+      <div className={s.outlet}>{children ? children : <Outlet />}</div>
     </>
   );
 }


### PR DESCRIPTION
# Summary #
The error site was not loading properly when an invalid path was entered. This PR fixes that

## Description ## 
The issue was a missing prop passed to the function in charge of rendering the Notfound component